### PR TITLE
SphinxDrvReg no longer neede and no longer exists.

### DIFF
--- a/App/FSWInfo/FSWInfoComponentImpl.hpp
+++ b/App/FSWInfo/FSWInfoComponentImpl.hpp
@@ -13,7 +13,6 @@
 #define FSWInfo_HPP
 
 #include "App/FSWInfo/FSWInfoComponentAc.hpp"
-#include "fprime-sphinx-drivers/Util/SphinxDrvReg.hpp"
 
 // generated and linked at build time
 extern const char* FSW_VERSION;


### PR DESCRIPTION
Removed the inclusion of a file that is no longer needed and has been deleted in fprime-sphinx-driver's master repo.
Also, updated fprime-sphinx-driver's pointer.